### PR TITLE
Harden event user serialization for CVE-2017-2603

### DIFF
--- a/source/xzs/pom.xml
+++ b/source/xzs/pom.xml
@@ -20,6 +20,8 @@
         <java.version>1.8</java.version>
         <mysql.version>8.0.17</mysql.version>
         <spring.boot.version>2.1.6.RELEASE</spring.boot.version>
+        <!-- Preserve previous default: unit tests off unless -Dskip.unit.tests=false -->
+        <skip.unit.tests>true</skip.unit.tests>
     </properties>
 
 
@@ -181,7 +183,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skipTests>true</skipTests>
+                    <skipTests>${skip.unit.tests}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/source/xzs/src/main/java/com/mindskip/xzs/event/OnRegistrationCompleteEvent.java
+++ b/source/xzs/src/main/java/com/mindskip/xzs/event/OnRegistrationCompleteEvent.java
@@ -12,7 +12,10 @@ import org.springframework.context.ApplicationEvent;
 public class OnRegistrationCompleteEvent extends ApplicationEvent {
 
 
-    private final User user;
+    /**
+     * Avoid serializing full user details when this event is persisted.
+     */
+    private final transient User user;
 
 
     /**

--- a/source/xzs/src/test/java/com/mindskip/xzs/event/OnRegistrationCompleteEventSerializationTest.java
+++ b/source/xzs/src/test/java/com/mindskip/xzs/event/OnRegistrationCompleteEventSerializationTest.java
@@ -1,0 +1,38 @@
+package com.mindskip.xzs.event;
+
+import com.mindskip.xzs.domain.User;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.Assert.assertNull;
+
+public class OnRegistrationCompleteEventSerializationTest {
+
+    @Test
+    public void dedicatedUserFieldIsNotSerialized() throws Exception {
+        User user = new User();
+        user.setId(1);
+        user.setUserName("alice");
+        user.setPassword("secret-password");
+
+        OnRegistrationCompleteEvent event = new OnRegistrationCompleteEvent(user);
+
+        byte[] bytes;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(event);
+            bytes = baos.toByteArray();
+        }
+
+        OnRegistrationCompleteEvent deserialized;
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            deserialized = (OnRegistrationCompleteEvent) ois.readObject();
+        }
+
+        assertNull("transient user field should not survive serialization", deserialized.getUser());
+    }
+}


### PR DESCRIPTION
## Summary
- Mark `OnRegistrationCompleteEvent` dedicated `User` field as `transient` to avoid persisting full user details in serialized event state.
- Add a focused serialization regression test proving the field is not rehydrated after `ObjectOutputStream`/`ObjectInputStream` roundtrip.
- Replace hardcoded Surefire `skipTests=true` with a property (`skip.unit.tests`, default `true`) so verification tests can be executed without changing default project behavior.

## Reproduction (before fix)
- In `source/xzs/src/main/java/com/mindskip/xzs/event/OnRegistrationCompleteEvent.java`, the event stored `private final User user;`.
- `User` contains sensitive fields (including `password`), so Java serialization of this event could persist unnecessary user details.

## Verification (after fix)
- `source/xzs/src/main/java/com/mindskip/xzs/event/OnRegistrationCompleteEvent.java` now uses `private final transient User user;`.
- Added `source/xzs/src/test/java/com/mindskip/xzs/event/OnRegistrationCompleteEventSerializationTest.java` to validate serialization behavior.

## Test plan
- [x] `export JAVA_HOME="/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home" && export PATH="$JAVA_HOME/bin:/opt/homebrew/bin:$PATH" && cd source/xzs && mvn -DskipTests compile`
- [x] `export JAVA_HOME="/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home" && export PATH="$JAVA_HOME/bin:/opt/homebrew/bin:$PATH" && cd source/xzs && mvn test -Dskip.unit.tests=false`
- [x] `cd source/xzs && mvn test` (confirms default behavior remains `Tests are skipped.`)

## Scope and risk
- Minimal change set: one event field hardening + one focused test + test skip flag parameterization.
- No vendored/third-party code modified.